### PR TITLE
Fix trailing parsing and typos

### DIFF
--- a/lib/elixircd/commands/userhost.ex
+++ b/lib/elixircd/commands/userhost.ex
@@ -1,6 +1,6 @@
 defmodule ElixIRCd.Commands.Userhost do
   @moduledoc """
-  This module defines the USER command.
+  This module defines the USERHOST command.
   """
 
   @behaviour ElixIRCd.Command

--- a/lib/elixircd/message.ex
+++ b/lib/elixircd/message.ex
@@ -204,8 +204,8 @@ defmodule ElixIRCd.Message do
   # Extracts the trailing from the parameters if present.
   @spec extract_trailing([String.t()]) :: {[String.t()], String.t() | nil}
   defp extract_trailing(parts) do
-    # Find the index of the part where the trailing begins (first part containing a ':')
-    trailing_index = Enum.find_index(parts, &String.contains?(&1, ":"))
+    # Find the index of the part where the trailing begins (first part starting with ':')
+    trailing_index = Enum.find_index(parts, &String.starts_with?(&1, ":"))
 
     case trailing_index do
       nil ->

--- a/lib/elixircd/utils/network.ex
+++ b/lib/elixircd/utils/network.ex
@@ -4,7 +4,7 @@ defmodule ElixIRCd.Utils.Network do
   """
 
   @doc """
-  Lookups the hostname for an IP address.
+  Looks up the hostname for an IP address.
   """
   @spec lookup_hostname(ip_address :: :inet.ip_address()) :: {:ok, String.t()} | {:error, String.t()}
   def lookup_hostname(ip_address) do

--- a/test/elixircd/message_test.exs
+++ b/test/elixircd/message_test.exs
@@ -197,6 +197,21 @@ defmodule ElixIRCd.MessageTest do
       assert Message.parse(raw_message) == expected
     end
 
+    test "parses a raw message with colon inside a parameter" do
+      raw_message = ":Nick!user@host MODE #channel +b nick:user@host"
+
+      expected =
+        {:ok,
+         %Message{
+           prefix: "Nick!user@host",
+           command: "MODE",
+           params: ["#channel", "+b", "nick:user@host"],
+           trailing: nil
+         }}
+
+      assert Message.parse(raw_message) == expected
+    end
+
     test "handles malformed raw messages" do
       assert Message.parse(":unexpected") ==
                {:error, "Invalid IRC message format on parsing command and params: \"\""}


### PR DESCRIPTION
## Summary
- fix a small typo in Network utils docstring
- correct the trailing parser in `Message` and clarify comment
- fix Userhost command module docstring
- add a test for colon handling in message parameters

## Testing
- `mix deps.get` *(fails: Unknown package erlex in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6842d9af3b948326bcd3d75f7465f6e3